### PR TITLE
Skip the install of a few big conda env

### DIFF
--- a/genome_annotation_tools_1.yml
+++ b/genome_annotation_tools_1.yml
@@ -43,6 +43,7 @@ install_tool_dependencies: False
 tools:
 - name: data_manager_fetch_busco
   owner: iuc
+  install_resolver_dependencies: False
   tool_panel_section_label: "Similarity Search"
 
 - name: busco

--- a/genome_annotation_tools_2.yml
+++ b/genome_annotation_tools_2.yml
@@ -64,4 +64,5 @@ tools:
 
 - name: ncbi_blast_plus
   owner: devteam
+  install_resolver_dependencies: False
   tool_panel_section_label: "Similarity Search"

--- a/genome_annotation_tools_3.yml
+++ b/genome_annotation_tools_3.yml
@@ -43,6 +43,7 @@ install_tool_dependencies: False
 tools:
 - name: blast_rbh
   owner: peterjc
+  install_resolver_dependencies: False
   tool_panel_section_label: "Similarity Search"
 
 - name: blastxml_to_top_descr
@@ -71,10 +72,12 @@ tools:
 
 - name: diamond
   owner: bgruening
+  install_resolver_dependencies: False
   tool_panel_section_label: "Similarity Search"
 
 - name: data_manager_diamond_database_builder
   owner: bgruening
+  install_resolver_dependencies: False
   tool_panel_section_label: "Similarity Search"
 
 - name: suite_glimmer
@@ -115,6 +118,7 @@ tools:
 
 - name: weblogo3
   owner: devteam
+  install_resolver_dependencies: False
   tool_panel_section_label: "Visualisation"
 
 - name: suite_chado

--- a/genome_annotation_tools_3.yml
+++ b/genome_annotation_tools_3.yml
@@ -97,7 +97,7 @@ tools:
   tool_panel_section_label: "Assembly"
 
 - name: cdhit
-  owner: jjohnson
+  owner: bebatut
   tool_panel_section_label: "Clustering"
 
 - name: clustalw


### PR DESCRIPTION
Skip the install of a few big conda env to reduce the image size. Currently the image does not build anymore on quay.io because it's too big